### PR TITLE
fix quota usage increase in the case of replication

### DIFF
--- a/hydroshare.re
+++ b/hydroshare.re
@@ -30,7 +30,7 @@ acPostProcForCopy () {
 
 # catch "iput" command
 acPostProcForPut () {
-    # work around to not call msiHSAddNewFile in the case of irepl and only call it in the case of iput
+    # work around to not call msiHSAddNewFile in the case of irepl ($oprType==6) and only call it in the case of iput ($oprType==1)
     if ($oprType == 1)
     then {
         msiHSAddNewFile($objPath, "/hydroshareZone/home/cuahsiDataProxy/bags", "quotaUserName", "Federated", "hsuser", "dummy", "local.hs.org/hsapi/_internal/update_quota_usage/"); 

--- a/hydroshare.re
+++ b/hydroshare.re
@@ -30,7 +30,11 @@ acPostProcForCopy () {
 
 # catch "iput" command
 acPostProcForPut () {
-    msiHSAddNewFile($objPath, "/hydroshareZone/home/cuahsiDataProxy/bags", "quotaUserName", "Federated", "hsuser", "dummy", "local.hs.org/hsapi/_internal/update_quota_usage/"); 
+    # work around to not call msiHSAddNewFile in the case of irepl and only call it in the case of iput
+    if ($oprType == 1)
+    then {
+        msiHSAddNewFile($objPath, "/hydroshareZone/home/cuahsiDataProxy/bags", "quotaUserName", "Federated", "hsuser", "dummy", "local.hs.org/hsapi/_internal/update_quota_usage/"); 
+    }
 }
 
 # catch "imeta" command if any new "quotaUserName" or "resetQuotaDir" are set


### PR DESCRIPTION
@cbcunc Here is the PR that fixes quota usage increase in the case of replication. The fix is already deployed on production and beta. A quota reset needs to be run on production to reset wrong quota usage values. Hopefully with this fix, quota usage will become stable and we only need to run quota reset on demand when quota could be potentially impacted.