### PR TITLE
test no HS api call in irods quota microservices

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -40,26 +40,7 @@ void _debug(long long val) {
 
 //---------------------------------------------------------
 void callRestAPI(char * user, char *pass, char *url) {
-  CURL *curl;
-  CURLcode res;
-
-  rodsLog(LOG_NOTICE, "url: %s\n", url);
-
-  curl_global_init(CURL_GLOBAL_ALL);
-  curl = curl_easy_init();
-  if(curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, url);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
-    res = curl_easy_perform(curl);
-    if(res != CURLE_OK) {
-    	rodsLog(LOG_ERROR, "curl_easy_perform() failed: %s", curl_easy_strerror(res));
-    }
-    curl_easy_cleanup(curl);
-    curl_global_cleanup();
-  }
-  else {
-    rodsLog(LOG_ERROR, "cannot init curl");
-  }
+    // Test not calling Hydroshare restAPI
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
@cbcunc is it tedious to do the cmake and install the rpm on beta?
If NOT, I was thinking it would be interesting to see what removing the HS api calls from the quota microservices does to the performance during `irm` etc.

My thinking is that if removing the api calls improves performance drastically, we could configure async signals in django to reach out for irods metadata (and update the quotas in Django) so that the process is non-blocking