### PR TITLE
Make `msiHSRemoveFile` take quota holder username and data size

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -683,9 +683,8 @@ bool getParentQuotaHolder(char *dirPath, char * quotaHolderAVU, char * quotaHold
 }
 
 //---------------------------------------------------------
-int decreaseUsage(char * filePath, char * bags, char * oldOwner) {
+int decreaseUsage(long long fileSize, char * bags, char * oldOwner) {
 
-    long long fileSize = getRodsFileSize(filePath);
     if (fileSize <= 0) return fileSize;
 
     char *avuOwner = concat(oldOwner, usageSize);


### PR DESCRIPTION
This has NOT been compiled and tested.

The MSI has been updated as follows:
- Accepts an eighth parameter representing the quota holder username
- Checks the parameter for correctness
- Removed quota holder username resolution logic